### PR TITLE
Made the item row editable

### DIFF
--- a/components/Dashboard.js
+++ b/components/Dashboard.js
@@ -147,7 +147,7 @@ export default function Dashboard() {
   const [openRecipeSuggestion, setOpenRecipeSuggestion] = useState(false);
   const [cameraMode, setCameraMode] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
-
+  const [errorMessage, setErrorMessage] = useState("");
   const toggleDarkMode = () => setDarkMode(!darkMode);
 
   const customTheme = createTheme({
@@ -256,7 +256,7 @@ export default function Dashboard() {
     setEditItemQuantity(inventory[item]);
   };
 
-  const handleSaveEdit = async (oldName, newName) => {
+  const handleSaveNameEdit = async (oldName, newName) => {
     if (!newName || !oldName) {
       console.log("Error: newName or oldName is null or undefined");
       return;
@@ -293,8 +293,22 @@ export default function Dashboard() {
 
   const handleSaveQuantityEdit = async (item) => {
     const newQuantity = Math.max(0, parseInt(editItemQuantity, 10) || 0);
+    if (newQuantity === 0) {
+      setErrorMessage("Quantity cannot be 0");
+      return true;
+    }
     await updateInventory(item, newQuantity - (inventory[item] || 0));
     setEditItemQuantity(0);
+    setErrorMessage("");
+    return false;
+  };
+
+  const handleSaveEdit = async (item) => {
+    const quantityError = await handleSaveQuantityEdit(item);
+    if (quantityError) {
+      return;
+    }
+    handleSaveNameEdit(item, editItemName);
   };
 
   return (
@@ -472,54 +486,62 @@ export default function Dashboard() {
                                   <TextField
                                     type="number"
                                     value={editItemQuantity}
-                                    onChange={(e) =>
-                                      setEditItemQuantity(e.target.value)
-                                    }
+                                    onChange={(e) => {
+                                      setEditItemQuantity(e.target.value);
+                                      setErrorMessage("");
+                                    }}
                                     size="small"
                                     inputProps={{ min: 0 }}
+                                    style={{ width: 100 }}
+                                    error={!!errorMessage}
+                                    helperText={errorMessage}
                                   />
                                 ) : (
                                   quantity
                                 )}
                               </StyledTableCell>
                               <StyledTableCell align="right">
-                                <ActionButton
-                                  onClick={() => updateInventory(item, 1)}
-                                >
-                                  <AddIcon />
-                                </ActionButton>
-                                <ActionButton
-                                  onClick={() => updateInventory(item, -1)}
-                                >
-                                  <RemoveIcon />
-                                </ActionButton>
-                                <ActionButton
-                                  onClick={() =>
-                                    setDeleteConfirmation({ open: true, item })
-                                  }
-                                >
-                                  <DeleteIcon />
-                                </ActionButton>
                                 {editItem === item ? (
                                   <StyledButton
                                     variant="outlined"
                                     color="primary"
-                                    startIcon={<SaveIcon />}
+                                    //startIcon={<SaveIcon />}
                                     onClick={() => {
-                                      handleSaveQuantityEdit(item);
-                                      handleSaveEdit(item, editItemName);
+                                      handleSaveEdit(item);
                                     }}
                                   >
                                     Save
                                   </StyledButton>
                                 ) : (
-                                  <ActionButton
-                                    onClick={() => {
-                                      handleEdit(item);
-                                    }}
-                                  >
-                                    <EditIcon />
-                                  </ActionButton>
+                                  <>
+                                    <ActionButton
+                                      onClick={() => updateInventory(item, 1)}
+                                    >
+                                      <AddIcon />
+                                    </ActionButton>
+                                    <ActionButton
+                                      onClick={() => updateInventory(item, -1)}
+                                    >
+                                      <RemoveIcon />
+                                    </ActionButton>
+                                    <ActionButton
+                                      onClick={() =>
+                                        setDeleteConfirmation({
+                                          open: true,
+                                          item,
+                                        })
+                                      }
+                                    >
+                                      <DeleteIcon />
+                                    </ActionButton>
+                                    <ActionButton
+                                      onClick={() => {
+                                        handleEdit(item);
+                                      }}
+                                    >
+                                      <EditIcon />
+                                    </ActionButton>
+                                  </>
                                 )}
                               </StyledTableCell>
                             </TableRow>


### PR DESCRIPTION
### Description

This PR introduces an edit button for each row in the inventory list. When clicked, the name and quantity of the item become editable. If the user attempts to save with an empty name, a quantity of 0, or a name that already exists in the list, an error message is displayed. If no errors are present, the inventory list updates with the new name and/or quantity.

Related Issues:  [Make the item row editable #5](https://github.com/miyannishar/inventory-management/issues/5)


### Changes

All changes are made in the Dashboard.js:

- Added edit and save buttons to every item's row.
- Implemented states and functions to manage the display of the editable row and to update the database.


### Additional note

Since the items in the database do not have individual IDs and instead use the item name as the unique key, I was unable to directly update the item's name. Instead, the process involves deleting the existing item and creating a new item with the updated name which can either retain the former quantity or include a new one. If only the quantity is being updated, the item remains unchanged in terms of its name.


### Testing

I have tested the page on localhost using both Chrome and Firefox. The functionality performed as expected without any errors during my tests.


### Screenshots
Intial state:
<img width="952" alt="Screenshot 2024-10-03 at 14 51 53" src="https://github.com/user-attachments/assets/858360cb-e079-414c-a238-ede131005fda">

Editable state:
<img width="949" alt="Screenshot 2024-10-03 at 14 52 05" src="https://github.com/user-attachments/assets/83783213-fc6d-437a-a967-5672fccfb116">

If trying to save with 0 quantity:
<img width="950" alt="Screenshot 2024-10-03 at 14 52 25" src="https://github.com/user-attachments/assets/150ebead-576f-4a2c-bbad-e6c21f813cfb">


### Reviewers

@miyannishar 